### PR TITLE
Persist refreshed OAuth tokens

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -76,7 +77,57 @@ func TokenSource(ctx context.Context, cfg config.Config) (oauth2.TokenSource, er
 	if err != nil {
 		return nil, err
 	}
-	return oauthCfg.TokenSource(ctx, token), nil
+	return &persistingTokenSource{
+		source: oauthCfg.TokenSource(ctx, token),
+		last:   cloneToken(token),
+	}, nil
+}
+
+type persistingTokenSource struct {
+	source oauth2.TokenSource
+
+	mu   sync.Mutex
+	last *oauth2.Token
+}
+
+func (s *persistingTokenSource) Token() (*oauth2.Token, error) {
+	token, err := s.source.Token()
+	if err != nil {
+		return nil, err
+	}
+	if token == nil {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if tokenEqual(token, s.last) {
+		return token, nil
+	}
+	if err := SaveToken(token); err != nil {
+		return nil, err
+	}
+	s.last = cloneToken(token)
+	return token, nil
+}
+
+func cloneToken(token *oauth2.Token) *oauth2.Token {
+	if token == nil {
+		return nil
+	}
+	clone := *token
+	return &clone
+}
+
+func tokenEqual(a, b *oauth2.Token) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.AccessToken == b.AccessToken &&
+		a.TokenType == b.TokenType &&
+		a.RefreshToken == b.RefreshToken &&
+		a.Expiry.Equal(b.Expiry) &&
+		a.ExpiresIn == b.ExpiresIn
 }
 
 func Login(ctx context.Context, cfg config.Config, opts LoginOptions) (*oauth2.Token, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/rudrankriyam/Google-Health-CLI/internal/config"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestTokenSourcePersistsRefreshedToken(t *testing.T) {
+	tokenPath := configTokenPath(t)
+	expired := &oauth2.Token{
+		AccessToken:  "old-access-token",
+		TokenType:    "Bearer",
+		RefreshToken: "old-refresh-token",
+		Expiry:       time.Now().Add(-time.Hour),
+	}
+	if err := SaveToken(expired); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	var refreshCalls int
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		refreshCalls++
+		if req.Method != http.MethodPost {
+			t.Fatalf("refresh method = %s, want POST", req.Method)
+		}
+		if got := req.URL.String(); got != "https://oauth2.googleapis.com/token" {
+			t.Fatalf("refresh URL = %s", got)
+		}
+		if err := req.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		wantForm := url.Values{
+			"client_id":     {"client-id"},
+			"client_secret": {"client-secret"},
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {"old-refresh-token"},
+		}
+		for key, want := range wantForm {
+			if got := req.Form[key]; len(got) != len(want) || got[0] != want[0] {
+				t.Fatalf("form[%s] = %v, want %v", key, got, want)
+			}
+		}
+		return jsonResponse(t, map[string]any{
+			"access_token":  "new-access-token",
+			"token_type":    "Bearer",
+			"refresh_token": "new-refresh-token",
+			"expires_in":    3600,
+		}), nil
+	})}
+
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+	source, err := TokenSource(ctx, config.Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		RedirectURL:  config.DefaultRedirectURL,
+	})
+	if err != nil {
+		t.Fatalf("TokenSource() error = %v", err)
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token.AccessToken != "new-access-token" {
+		t.Fatalf("AccessToken = %q", token.AccessToken)
+	}
+	if token.RefreshToken != "new-refresh-token" {
+		t.Fatalf("RefreshToken = %q", token.RefreshToken)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", refreshCalls)
+	}
+
+	stored, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken() error = %v", err)
+	}
+	if stored.AccessToken != "new-access-token" {
+		t.Fatalf("stored AccessToken = %q", stored.AccessToken)
+	}
+	if stored.RefreshToken != "new-refresh-token" {
+		t.Fatalf("stored RefreshToken = %q", stored.RefreshToken)
+	}
+	if !stored.Valid() {
+		t.Fatalf("stored token is not valid: %#v", stored)
+	}
+	info, err := os.Stat(tokenPath)
+	if err != nil {
+		t.Fatalf("Stat(%q) error = %v", tokenPath, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("token mode = %v, want 0600", got)
+	}
+}
+
+func configTokenPath(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/token.json"
+	t.Setenv("GHEALTH_TOKEN_FILE", path)
+	return path
+}
+
+func jsonResponse(t *testing.T, payload any) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}


### PR DESCRIPTION
## Summary
- wrap the OAuth token source so refreshed access/refresh tokens are saved back to the existing token file
- add focused auth-package coverage for refresh persistence and token file permissions

## Tests
- go test ./internal/auth -v
- go test ./...
- go build ./...

## Remaining security debt
- OAuth tokens are still stored as plaintext JSON on disk, albeit with 0600 file permissions
- configured client secrets are still stored as plaintext in config.json
- this PR intentionally avoids a broader keychain/secure-store redesign