### PR TITLE
Fix audited defects: callback server hazards, dead code, date validation, config tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 - Added endpoint coverage documentation.
 - Added missing client options for `updateMask`, subscriber pagination and force deletion, `dataSourceFamily`, and partial TCX export.
 - Fixed CLI rollup request bodies to send documented `range` payloads instead of filter strings.
+- Added nutrition data types to the registry.
+- Persisted refreshed OAuth tokens so long-running sessions stay logged in.
+- Added an opt-in macOS Keychain token storage backend (`GHEALTH_TOKEN_STORAGE=keychain`); the plaintext file remains the default.
+- Fixed the OAuth callback server so duplicate callback requests can never block the handler, and gave server shutdown a 5-second timeout.
+- Fixed `ghealth auth login` to surface config save failures instead of silently ignoring them.
+- Fixed `ghealth help` and `ghealth version` to keep working when the config file is corrupt.
+- Fixed civil date parsing to reject out-of-range months and days.
+- Added tests for `internal/config` (round-trip, defaults, corrupt file).
+- Removed unused `auth.AuthURL`, `healthapi.IsNotLoggedIn`, and `healthapi.IsAPIError` helpers and a dead nil-check on `oauth2.NewClient`.
 
 ## 1.0.0
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,4 +12,8 @@ Please report security issues privately by email to the repository owner. Do not
 
 ## Local Secrets
 
-`ghealth` stores OAuth tokens in the user config directory with file mode `0600`. Do not commit local config or token files.
+By default `ghealth` stores the OAuth token as a plaintext JSON file (`token.json`, file mode `0600`) in the user config directory. Anyone with read access to that directory (or to an unencrypted backup of it) can read the token, so enable OS-level disk encryption such as FileVault (macOS), LUKS (Linux), or BitLocker (Windows).
+
+On macOS you can opt in to storing the token in the Keychain instead of a file by setting `GHEALTH_TOKEN_STORAGE=keychain` before running `ghealth auth login`. The token is then kept as a generic password (service `ghealth`) managed by `/usr/bin/security`. If you switch backends after logging in, remove the old copy: `ghealth auth revoke --yes` deletes the token from whichever backend is currently selected.
+
+Do not commit local config or token files.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -44,13 +43,7 @@ func Run(args []string, version string) int {
 		version: version,
 		opts:    output.Options{Format: output.FormatAuto},
 	}
-	cfg, err := config.Load()
-	if err == nil {
-		a.cfg = cfg
-	}
-	if err == nil {
-		err = a.run()
-	}
+	err := a.loadConfigAndRun()
 	if err != nil {
 		output.PrintError(a.errOut, unwrapUsage(err), a.opts, hintFor(err))
 	}
@@ -65,17 +58,36 @@ func RunWithWriters(args []string, version string, stdout, stderr io.Writer) int
 		version: version,
 		opts:    output.Options{Format: output.FormatJSON},
 	}
-	cfg, err := config.Load()
-	if err == nil {
-		a.cfg = cfg
-	}
-	if err == nil {
-		err = a.run()
-	}
+	err := a.loadConfigAndRun()
 	if err != nil {
 		output.PrintError(a.errOut, unwrapUsage(err), a.opts, hintFor(err))
 	}
 	return exitCodeFromError(err)
+}
+
+// loadConfigAndRun loads the config and executes the requested command.
+// Help and version must keep working even when the config file is
+// unreadable, so a config load error is only fatal for other commands.
+func (a *app) loadConfigAndRun() error {
+	cfg, cfgErr := config.Load()
+	a.cfg = cfg
+	if cfgErr != nil && !helpOrVersionRequested(a.args) {
+		return cfgErr
+	}
+	return a.run()
+}
+
+func helpOrVersionRequested(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	for _, arg := range args {
+		switch arg {
+		case "help", "-h", "--help", "version", "--version":
+			return true
+		}
+	}
+	return false
 }
 
 func (a *app) run() error {
@@ -836,9 +848,6 @@ func (a *app) client() (*healthapi.Client, error) {
 		return nil, fmt.Errorf("%w: %w", errAuth, err)
 	}
 	httpClient := oauth2.NewClient(context.Background(), source)
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
 	return healthapi.New(a.cfg.BaseURL, a.cfg.User, httpClient), nil
 }
 
@@ -915,9 +924,15 @@ func civilDateTime(value string) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if month < 1 || month > 12 {
+		return nil, fmt.Errorf("invalid month %d: must be between 1 and 12", month)
+	}
 	day, err := parsePositiveInt(parts[2])
 	if err != nil {
 		return nil, err
+	}
+	if day < 1 || day > 31 {
+		return nil, fmt.Errorf("invalid day %d: must be between 1 and 31", day)
 	}
 	result := map[string]any{"date": map[string]any{"year": year, "month": month, "day": day}}
 	if timePart != "" {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -59,5 +62,90 @@ func TestAPICallWithoutTokenReturnsJSONAuthError(t *testing.T) {
 	}
 	if payload["message"] == "" || payload["message"] == "unknown error" {
 		t.Fatalf("message = %q, payload = %#v", payload["message"], payload)
+	}
+}
+
+func TestCivilDateTimeValid(t *testing.T) {
+	value, err := civilDateTime("2026-05-08")
+	if err != nil {
+		t.Fatalf("civilDateTime: %v", err)
+	}
+	date, ok := value["date"].(map[string]any)
+	if !ok {
+		t.Fatalf("date missing: %#v", value)
+	}
+	if date["year"] != 2026 || date["month"] != 5 || date["day"] != 8 {
+		t.Fatalf("date = %#v", date)
+	}
+	if _, hasTime := value["time"]; hasTime {
+		t.Fatalf("unexpected time component: %#v", value)
+	}
+
+	value, err = civilDateTime("2026-12-31T23:59:07Z")
+	if err != nil {
+		t.Fatalf("civilDateTime with time: %v", err)
+	}
+	clock, ok := value["time"].(map[string]any)
+	if !ok {
+		t.Fatalf("time missing: %#v", value)
+	}
+	if clock["hours"] != 23 || clock["minutes"] != 59 || clock["seconds"] != 7 {
+		t.Fatalf("time = %#v", clock)
+	}
+}
+
+func TestCivilDateTimeInvalid(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr string
+	}{
+		{"2026-13-01", "invalid month"},
+		{"2026-00-01", "invalid month"},
+		{"2026-01-32", "invalid day"},
+		{"2026-01-00", "invalid day"},
+		{"2026-01", "expected YYYY-MM-DD"},
+		{"2026-01-02T25", "expected time"},
+		{"2026-0a-01", "invalid number"},
+	}
+	for _, tc := range cases {
+		_, err := civilDateTime(tc.input)
+		if err == nil {
+			t.Fatalf("civilDateTime(%q): expected error", tc.input)
+		}
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("civilDateTime(%q) error = %q, want substring %q", tc.input, err, tc.wantErr)
+		}
+	}
+}
+
+func TestHelpAndVersionWorkWithCorruptConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GHEALTH_CONFIG_DIR", dir)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := RunWithWriters([]string{"help"}, "test", &stdout, &stderr); code != ExitSuccess {
+		t.Fatalf("help exit = %d, stderr = %s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("Usage:")) {
+		t.Fatalf("help output = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := RunWithWriters([]string{"--version"}, "1.2.3-test", &stdout, &stderr); code != ExitSuccess {
+		t.Fatalf("version exit = %d, stderr = %s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "1.2.3-test" {
+		t.Fatalf("version output = %q", stdout.String())
+	}
+
+	// Other commands still surface the config error.
+	stdout.Reset()
+	stderr.Reset()
+	if code := RunWithWriters([]string{"types", "list"}, "test", &stdout, &stderr); code == ExitSuccess {
+		t.Fatalf("types list with corrupt config: expected failure, stdout = %s", stdout.String())
 	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -170,6 +169,21 @@ func Login(ctx context.Context, cfg config.Config, opts LoginOptions) (*oauth2.T
 
 	codeCh := make(chan string, 1)
 	errCh := make(chan error, 1)
+	// Sends are non-blocking so duplicate callback hits (e.g. a browser
+	// re-requesting the redirect URL) can never block the HTTP handler;
+	// only the first result is consumed.
+	sendCode := func(code string) {
+		select {
+		case codeCh <- code:
+		default:
+		}
+	}
+	sendErr := func(err error) {
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
 	mux := http.NewServeMux()
 	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	listener, err := net.Listen("tcp", redirect.Host)
@@ -179,29 +193,33 @@ func Login(ctx context.Context, cfg config.Config, opts LoginOptions) (*oauth2.T
 	mux.HandleFunc(redirect.Path, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("state"); got != state {
 			http.Error(w, "state mismatch", http.StatusBadRequest)
-			errCh <- errors.New("OAuth state mismatch")
+			sendErr(errors.New("OAuth state mismatch"))
 			return
 		}
 		if value := r.URL.Query().Get("error"); value != "" {
 			http.Error(w, value, http.StatusBadRequest)
-			errCh <- fmt.Errorf("OAuth error: %s", value)
+			sendErr(fmt.Errorf("OAuth error: %s", value))
 			return
 		}
 		code := r.URL.Query().Get("code")
 		if code == "" {
 			http.Error(w, "missing code", http.StatusBadRequest)
-			errCh <- errors.New("OAuth callback did not include a code")
+			sendErr(errors.New("OAuth callback did not include a code"))
 			return
 		}
 		fmt.Fprintln(w, "ghealth login complete. You can close this tab.")
-		codeCh <- code
+		sendCode(code)
 	})
 	go func() {
 		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
+			sendErr(err)
 		}
 	}()
-	defer server.Shutdown(context.Background())
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
 
 	authURL := oauthCfg.AuthCodeURL(
 		state,
@@ -229,7 +247,9 @@ func Login(ctx context.Context, cfg config.Config, opts LoginOptions) (*oauth2.T
 			return nil, err
 		}
 		cfg.Scopes = oauthCfg.Scopes
-		_ = config.Save(cfg)
+		if err := config.Save(cfg); err != nil {
+			return nil, fmt.Errorf("login succeeded but saving config failed: %w", err)
+		}
 		return token, nil
 	case err := <-errCh:
 		return nil, err
@@ -240,34 +260,12 @@ func Login(ctx context.Context, cfg config.Config, opts LoginOptions) (*oauth2.T
 	}
 }
 
-func AuthURL(cfg config.Config, scopes []string) (string, error) {
-	oauthCfg, err := OAuthConfig(cfg, scopes)
-	if err != nil {
-		return "", err
-	}
-	codeChal, _, err := pkce()
-	if err != nil {
-		return "", err
-	}
-	state, err := randomString(32)
-	if err != nil {
-		return "", err
-	}
-	return oauthCfg.AuthCodeURL(
-		state,
-		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("prompt", "consent"),
-		oauth2.SetAuthURLParam("code_challenge", codeChal),
-		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
-	), nil
-}
-
 func LoadToken() (*oauth2.Token, error) {
-	path, err := config.TokenPath()
+	store, err := activeStore()
 	if err != nil {
 		return nil, err
 	}
-	bytes, err := os.ReadFile(path)
+	bytes, err := store.Read()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, errors.New("not logged in; run `ghealth auth login`")
@@ -285,11 +283,8 @@ func LoadToken() (*oauth2.Token, error) {
 }
 
 func SaveToken(token *oauth2.Token) error {
-	path, err := config.TokenPath()
+	store, err := activeStore()
 	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	bytes, err := json.MarshalIndent(token, "", "  ")
@@ -297,26 +292,24 @@ func SaveToken(token *oauth2.Token) error {
 		return err
 	}
 	bytes = append(bytes, '\n')
-	return os.WriteFile(path, bytes, 0o600)
+	return store.Write(bytes)
 }
 
 func RevokeLocal() error {
-	path, err := config.TokenPath()
+	store, err := activeStore()
 	if err != nil {
 		return err
 	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return nil
+	return store.Delete()
 }
 
 func CurrentStatus() Status {
-	path, err := config.TokenPath()
-	status := Status{TokenPath: path}
+	var status Status
+	store, err := activeStore()
 	if err != nil {
 		return status
 	}
+	status.TokenPath = store.Location()
 	token, err := LoadToken()
 	if err != nil {
 		return status

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/rudrankriyam/Google-Health-CLI/internal/config"
+)
+
+// TokenStore persists the raw OAuth token JSON. The default backend is a
+// plaintext file; set GHEALTH_TOKEN_STORAGE=keychain to opt in to the macOS
+// Keychain backend instead.
+type TokenStore interface {
+	// Read returns the stored token bytes, or an error wrapping
+	// os.ErrNotExist when no token is stored.
+	Read() ([]byte, error)
+	Write(data []byte) error
+	Delete() error
+	// Location is a human-readable description of where the token lives.
+	Location() string
+}
+
+func activeStore() (TokenStore, error) {
+	switch value := strings.ToLower(strings.TrimSpace(os.Getenv("GHEALTH_TOKEN_STORAGE"))); value {
+	case "", "file":
+		return fileStore{}, nil
+	case "keychain":
+		if runtime.GOOS != "darwin" {
+			return nil, errors.New("GHEALTH_TOKEN_STORAGE=keychain is only supported on macOS")
+		}
+		return keychainStore{run: securityRun}, nil
+	default:
+		return nil, fmt.Errorf("unknown GHEALTH_TOKEN_STORAGE %q (expected \"file\" or \"keychain\")", value)
+	}
+}
+
+// fileStore stores the token as a plaintext JSON file with mode 0600.
+type fileStore struct{}
+
+func (fileStore) Read() ([]byte, error) {
+	path, err := config.TokenPath()
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+func (fileStore) Write(data []byte) error {
+	path, err := config.TokenPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+func (fileStore) Delete() error {
+	path, err := config.TokenPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (fileStore) Location() string {
+	path, _ := config.TokenPath()
+	return path
+}
+
+const (
+	keychainService = "ghealth"
+	keychainAccount = "oauth-token"
+)
+
+// keychainStore stores the token as a base64-encoded generic password in the
+// macOS Keychain via /usr/bin/security. run is swappable for tests.
+type keychainStore struct {
+	run func(args ...string) ([]byte, error)
+}
+
+func (s keychainStore) Read() ([]byte, error) {
+	out, err := s.run("find-generic-password", "-s", keychainService, "-a", keychainAccount, "-w")
+	if err != nil {
+		return nil, err
+	}
+	data, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		return nil, fmt.Errorf("decode keychain token: %w", err)
+	}
+	return data, nil
+}
+
+func (s keychainStore) Write(data []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(data)
+	_, err := s.run("add-generic-password", "-U", "-s", keychainService, "-a", keychainAccount, "-w", encoded)
+	return err
+}
+
+func (s keychainStore) Delete() error {
+	_, err := s.run("delete-generic-password", "-s", keychainService, "-a", keychainAccount)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func (keychainStore) Location() string {
+	return fmt.Sprintf("macOS Keychain (service %q, account %q)", keychainService, keychainAccount)
+}
+
+// securityRun executes /usr/bin/security, mapping its "item not found" exit
+// code (44) to os.ErrNotExist.
+func securityRun(args ...string) ([]byte, error) {
+	cmd := exec.Command("/usr/bin/security", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 44 {
+			return nil, fmt.Errorf("keychain item not found: %w", os.ErrNotExist)
+		}
+		return nil, fmt.Errorf("security %s: %w: %s", args[0], err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// fakeSecurity emulates /usr/bin/security generic-password subcommands.
+type fakeSecurity struct {
+	items map[string]string
+	calls [][]string
+}
+
+func (f *fakeSecurity) run(args ...string) ([]byte, error) {
+	f.calls = append(f.calls, args)
+	flags := map[string]string{}
+	for i := 1; i < len(args)-1; i++ {
+		if args[i] == "-s" || args[i] == "-a" || args[i] == "-w" {
+			flags[args[i]] = args[i+1]
+		}
+	}
+	key := flags["-s"] + "/" + flags["-a"]
+	switch args[0] {
+	case "add-generic-password":
+		f.items[key] = flags["-w"]
+		return nil, nil
+	case "find-generic-password":
+		value, ok := f.items[key]
+		if !ok {
+			return nil, fmt.Errorf("keychain item not found: %w", os.ErrNotExist)
+		}
+		return []byte(value + "\n"), nil
+	case "delete-generic-password":
+		if _, ok := f.items[key]; !ok {
+			return nil, fmt.Errorf("keychain item not found: %w", os.ErrNotExist)
+		}
+		delete(f.items, key)
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unexpected security command %q", args[0])
+	}
+}
+
+func TestKeychainStoreRoundTrip(t *testing.T) {
+	fake := &fakeSecurity{items: map[string]string{}}
+	store := keychainStore{run: fake.run}
+
+	if _, err := store.Read(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Read before Write: err = %v, want os.ErrNotExist", err)
+	}
+
+	payload := []byte("{\n  \"access_token\": \"abc\"\n}\n")
+	if err := store.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("Read = %q, want %q", got, payload)
+	}
+
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Read(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Read after Delete: err = %v, want os.ErrNotExist", err)
+	}
+	// Deleting an absent item is not an error.
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete of absent item: %v", err)
+	}
+}
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	t.Setenv("GHEALTH_TOKEN_FILE", filepath.Join(t.TempDir(), "token.json"))
+	store := fileStore{}
+
+	if _, err := store.Read(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Read before Write: err = %v, want os.ErrNotExist", err)
+	}
+	if err := store.Write([]byte("{}")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != "{}" {
+		t.Fatalf("Read = %q, want {}", got)
+	}
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Read(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Read after Delete: err = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestActiveStoreSelection(t *testing.T) {
+	t.Setenv("GHEALTH_TOKEN_STORAGE", "")
+	store, err := activeStore()
+	if err != nil {
+		t.Fatalf("default store: %v", err)
+	}
+	if _, ok := store.(fileStore); !ok {
+		t.Fatalf("default store = %T, want fileStore", store)
+	}
+
+	t.Setenv("GHEALTH_TOKEN_STORAGE", "vault")
+	if _, err := activeStore(); err == nil {
+		t.Fatal("unknown backend: expected error")
+	}
+
+	t.Setenv("GHEALTH_TOKEN_STORAGE", "keychain")
+	store, err = activeStore()
+	if runtime.GOOS == "darwin" {
+		if err != nil {
+			t.Fatalf("keychain store on darwin: %v", err)
+		}
+		if _, ok := store.(keychainStore); !ok {
+			t.Fatalf("keychain store = %T, want keychainStore", store)
+		}
+	} else if err == nil {
+		t.Fatal("keychain store off darwin: expected error")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GHEALTH_CONFIG_DIR", dir)
+	// Make sure environment overrides do not leak into assertions.
+	for _, key := range []string{
+		"GHEALTH_BASE_URL", "GHEALTH_USER", "GHEALTH_PROJECT",
+		"GHEALTH_CLIENT_ID", "GHEALTH_CLIENT_SECRET", "GHEALTH_REDIRECT_URI", "GHEALTH_SCOPES",
+	} {
+		t.Setenv(key, "")
+	}
+	return dir
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	setConfigDir(t)
+
+	saved := Config{
+		BaseURL:      "https://example.com/api/",
+		User:         "/users/someone/",
+		Project:      "my-project",
+		ClientID:     " client-id ",
+		ClientSecret: "client-secret",
+		RedirectURL:  "http://127.0.0.1:9999/callback",
+		Scopes:       []string{"scope-a", "scope-b"},
+	}
+	if err := Save(saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.BaseURL != "https://example.com/api" {
+		t.Fatalf("BaseURL = %q", loaded.BaseURL)
+	}
+	if loaded.User != "users/someone" {
+		t.Fatalf("User = %q", loaded.User)
+	}
+	if loaded.Project != "my-project" {
+		t.Fatalf("Project = %q", loaded.Project)
+	}
+	if loaded.ClientID != "client-id" {
+		t.Fatalf("ClientID = %q", loaded.ClientID)
+	}
+	if loaded.ClientSecret != "client-secret" {
+		t.Fatalf("ClientSecret = %q", loaded.ClientSecret)
+	}
+	if loaded.RedirectURL != "http://127.0.0.1:9999/callback" {
+		t.Fatalf("RedirectURL = %q", loaded.RedirectURL)
+	}
+	if len(loaded.Scopes) != 2 || loaded.Scopes[0] != "scope-a" || loaded.Scopes[1] != "scope-b" {
+		t.Fatalf("Scopes = %#v", loaded.Scopes)
+	}
+}
+
+func TestLoadMissingFileUsesDefaults(t *testing.T) {
+	setConfigDir(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BaseURL != DefaultBaseURL {
+		t.Fatalf("BaseURL = %q, want %q", cfg.BaseURL, DefaultBaseURL)
+	}
+	if cfg.User != DefaultUser {
+		t.Fatalf("User = %q, want %q", cfg.User, DefaultUser)
+	}
+	if cfg.RedirectURL != DefaultRedirectURL {
+		t.Fatalf("RedirectURL = %q, want %q", cfg.RedirectURL, DefaultRedirectURL)
+	}
+}
+
+func TestLoadCorruptFileReturnsError(t *testing.T) {
+	dir := setConfigDir(t)
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err == nil {
+		t.Fatal("Load of corrupt config: expected error")
+	}
+}

--- a/internal/healthapi/client.go
+++ b/internal/healthapi/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -356,13 +355,4 @@ func updateQuery(updateMask string) url.Values {
 		query.Set("updateMask", updateMask)
 	}
 	return query
-}
-
-func IsNotLoggedIn(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "not logged in")
-}
-
-func IsAPIError(err error, status int) bool {
-	var apiErr *APIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == status
 }


### PR DESCRIPTION
Fixes a batch of audited defects.

## Dead/broken code removed
- `auth.AuthURL` generated a PKCE challenge and discarded the verifier (unusable by construction) and had no callers — deleted.
- `healthapi.IsNotLoggedIn` / `healthapi.IsAPIError` were uncalled — deleted.
- Removed the pointless nil-check on `oauth2.NewClient`'s return in `cmd/run.go` (it never returns nil), dropping the now-unused `net/http` import.

## OAuth callback server hardening (`internal/auth/auth.go`)
- All sends into `codeCh`/`errCh` are now non-blocking (`select`/`default`), so a duplicate callback hit (e.g. browser re-requesting the redirect URL) can never block the HTTP handler. First result wins.
- `server.Shutdown` now uses a 5-second timeout context instead of `context.Background()`.
- `config.Save` failures during `auth login` are now propagated (`login succeeded but saving config failed: ...`) instead of being silently discarded.

## Input validation
- `civilDateTime` now rejects months outside 1-12 and days outside 1-31 with clear errors; unit tests cover valid and invalid inputs.

## Config robustness + tests
- `ghealth help` and `ghealth version` now work even when `config.json` is corrupt; other commands still surface the load error. Covered by a test.
- New `internal/config` test suite: save/load round-trip with normalization, defaults when the file is missing, and the corrupt-file error path.

## Opt-in macOS Keychain token storage
- New `TokenStore` interface with the existing plaintext file as the default backend and an opt-in macOS Keychain backend (`GHEALTH_TOKEN_STORAGE=keychain`) that shells out to `/usr/bin/security` (token stored base64-encoded as a generic password, service `ghealth`). Tested against a fake `security` runner.
- `SECURITY.md` now documents the plaintext default, recommends OS-level disk encryption, and explains the keychain opt-in.

## Changelog
- The `1.0.1` section listed changes but no `1.0.1` tag exists (the repo's `1.0.0` tag already contained those entries). The section now accurately lists everything on `main` since `1.0.0` (nutrition types, refreshed-token persistence, and this PR) so a `1.0.1` tag can be cut at the merge commit.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` all green (41 passing tests, up from 32; `internal/config` previously had none).
- `gofmt -l .` clean.